### PR TITLE
Add .gitignore entries and GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+    
+    - name: Load cached venv
+      id: cached-poetry-dependencies
+      uses: actions/cache@v3
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+    
+    - name: Install dependencies
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction --no-root
+    
+    - name: Install project
+      run: poetry install --no-interaction
+    
+    - name: Run tests with coverage
+      run: |
+        poetry run pytest --cov=claude_container --cov-report=xml --cov-report=term
+    
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
+    
+    - name: Check coverage threshold
+      run: |
+        coverage_percentage=$(poetry run coverage report | grep TOTAL | awk '{print $4}' | sed 's/%//')
+        echo "Code coverage: $coverage_percentage%"
+        if (( $(echo "$coverage_percentage < 45" | bc -l) )); then
+          echo "Code coverage is below 45%. Current coverage: $coverage_percentage%"
+          exit 1
+        else
+          echo "Code coverage meets the threshold!"
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,15 @@ build/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+*.pyc
+
+# Coverage
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+*.cover
+.hypothesis/
 
 # Claude specific
 .claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add .gitignore entries for Python bytecode (.pyc) files and coverage reports
- Create GitHub Actions workflow to run tests with pytest-cov
- Configure pipeline to fail if code coverage drops below 45%

## Test plan
- [ ] GitHub Actions workflow runs successfully on PR
- [ ] Coverage check enforces 45% minimum threshold
- [ ] .pyc files and coverage reports are properly ignored

🤖 Generated with [Claude Code](https://claude.ai/code)