### PR TITLE
Remove project directory mounting and add git config to container builds

### DIFF
--- a/claude_container/core/container_runner.py
+++ b/claude_container/core/container_runner.py
@@ -181,10 +181,7 @@ class ContainerRunner:
     
     def _get_volumes(self) -> Dict[str, Dict[str, str]]:
         """Get volume mappings for the container."""
-        volumes = {
-            # Mount project directory to workspace
-            str(self.project_root): {'bind': DEFAULT_WORKDIR, 'mode': 'rw'}
-        }
+        volumes = {}
         
         # Mount Claude directory if it exists
         claude_dir = Path.home() / '.claude'

--- a/claude_container/core/docker_client.py
+++ b/claude_container/core/docker_client.py
@@ -41,14 +41,15 @@ class DockerClient:
         except Exception as e:
             print(f"Warning: Could not remove image {image_name}: {e}")
     
-    def build_image(self, path: str, dockerfile: str, tag: str, rm: bool = True, nocache: bool = False):
+    def build_image(self, path: str, dockerfile: str, tag: str, rm: bool = True, nocache: bool = False, buildargs: dict = None):
         """Build a Docker image."""
         return self.client.images.build(
             path=path,
             dockerfile=dockerfile,
             tag=tag,
             rm=rm,
-            nocache=nocache
+            nocache=nocache,
+            buildargs=buildargs
         )
     
     def run_container(self, image: str, command: str, **kwargs):

--- a/claude_container/core/dockerfile_template.py
+++ b/claude_container/core/dockerfile_template.py
@@ -2,6 +2,10 @@
 
 NODE_DOCKERFILE = """FROM node:20
 
+# Build arguments for git configuration
+ARG GIT_USER_EMAIL
+ARG GIT_USER_NAME
+
 # Install required system packages (minimal for now)
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
@@ -41,6 +45,10 @@ RUN git config --global --add safe.directory /workspace && \
 USER node
 RUN git config --global --add safe.directory /workspace && \
     git config --global --add safe.directory '*' && \
+    if [ -n "$GIT_USER_EMAIL" ] && [ -n "$GIT_USER_NAME" ]; then \
+        git config --global user.email "$GIT_USER_EMAIL" && \
+        git config --global user.name "$GIT_USER_NAME"; \
+    fi && \
     cd /workspace && \
     if [ -d .git ]; then \
         echo "Cleaning git repository state..." && \


### PR DESCRIPTION
- Remove host project directory mount from container volumes
- Containers now only use files copied during build process
- Add git user configuration check during build
- Pass git config as Docker build arguments
- Configure git inside container to prevent 'tell me who you are' errors
- Ensure proper isolation between host and container filesystems